### PR TITLE
added releases capability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,42 @@
 language: go
-
 sudo: required
-
 addons:
   apt:
     packages:
-      - redis-server
-      - lynx
-      - jq
-
+    - redis-server
+    - lynx
+    - jq
 go:
-  - "1.10"
-      
+- '1.10'
 before_script:
-  - sudo rsync -az ${TRAVIS_BUILD_DIR}/ /usr/local/bootstrap/
-  - pushd packer
-  - if [ $VAGRANT_CLOUD_TOKEN ] ; then packer validate template.json ; fi
-  - popd
-  - bash scripts/install_consul.sh
-  - bash scripts/install_vault.sh
-  - sudo cp /home/travis/.vault-token /usr/local/bootstrap/.vault-token
-       
+- sudo rsync -az ${TRAVIS_BUILD_DIR}/ /usr/local/bootstrap/
+- pushd packer
+- if [ $VAGRANT_CLOUD_TOKEN ] ; then packer validate template.json ; fi
+- popd
+- bash scripts/install_consul.sh
+- bash scripts/install_vault.sh
+- sudo cp /home/travis/.vault-token /usr/local/bootstrap/.vault-token
 script:
-  - source ./var.env
-  - export REDIS_MASTER_IP=127.0.0.1
-  - export REDIS_MASTER_PASSWORD=""
-  - export LISTENER_COUNT=1
-  - export LEADER_IP=127.0.0.1
-  - consul kv put "development/REDIS_MASTER_IP" "127.0.0.1"
-  - consul kv put "development/REDIS_MASTER_PASSWORD" ""
-  - consul kv put "development/LISTENER_COUNT" "1"
-  - consul kv put "development/LEADER_IP" "127.0.0.1"
-  - sudo VAULT_ADDR=http://127.0.0.1:8200 vault kv put secret/development/REDIS_MASTER_PASSWORD value=""
-  - sudo VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/development/REDIS_MASTER_PASSWORD
-  - sudo VAULT_ADDR=http://127.0.0.1:8200 vault status
-  - bash scripts/travis_run_go_app.sh
+- source ./var.env
+- export REDIS_MASTER_IP=127.0.0.1
+- export REDIS_MASTER_PASSWORD=""
+- export LISTENER_COUNT=1
+- export LEADER_IP=127.0.0.1
+- consul kv put "development/REDIS_MASTER_IP" "127.0.0.1"
+- consul kv put "development/REDIS_MASTER_PASSWORD" ""
+- consul kv put "development/LISTENER_COUNT" "1"
+- consul kv put "development/LEADER_IP" "127.0.0.1"
+- sudo VAULT_ADDR=http://127.0.0.1:8200 vault kv put secret/development/REDIS_MASTER_PASSWORD
+  value=""
+- sudo VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/development/REDIS_MASTER_PASSWORD
+- sudo VAULT_ADDR=http://127.0.0.1:8200 vault status
+- bash scripts/travis_run_go_app.sh
+deploy:
+  provider: releases
+  api_key:
+    secure: dAo/pXZ/jan3BcUA2bbhYl2v5QAW2JRAsaM0g077OJYxjUoepWarrb8puk0zdGfZ92ER+a7jwmXudbFVzk22Vp/aliIMkbrouQXVrXQaWZq0H45XD3grC5Pgbjdbn/s7gfCXk6IsZNkc1ztkpluFGox7iZXIYsrWJDvnjMNuhs6KWQpymKD8VQaQU1AqnWOOCWmkqLOy7pXtf9XQS44I5KkUibNFc5vxDqZriNCAkVSYZbvhmEphRb2iWGEtTxrJtU61Gj+fVpu6wpEO0JgWZNqmJTXgIXiPYb9i//uuRnA8qVym+PBl2azkMrmRV7TFbyzes1S5P5aWq0SgcYPKDtb7c5zJUzZkvpqkGDvriLUO2qyZq5PIC1Ega/bzLQMj/Nd8OMaJZjjoTNDc8frqQ9j84Q1WYTt1mhkMJF4LjXTar45nomR2GjBWfrETQBCGmO4fKYyNctx4cg8arz7MwftPIEt6orDegQzu8HR5oCX0hBvzDwK96JGtT8vfC4LfhtftTtTO2VqIMZ7lPbHzgyIswSBcVc9B7VIPS4Zka8JEzO1CRzeoL9u6HWNsUnre/U+twyxNmkZ1ZQW1kjeet8PT6S7eVRJuMofQJwhP42gz3yve8LaDaOxihlmD+UHnBVpDGSYl2ieLr+TAh2uwBNhs0bdEHJFNfwvNg9ySXKs=
+  file: webcounter
+  skip_cleanup: true
+  on:
+    repo: allthingsclowd/web_page_counter
+    tags: true


### PR DESCRIPTION
# Why is the PR required?

### New Feature:
Added release deployments to travis on tags

## What does this PR do?
Added release deployments to travis on tags

## How was this PR implemented?
added deploy section to .travis.yml
``` bash
.
.
.
deploy:
  provider: releases
  api_key:
    secure: dAo/pXZ/jan3BcUA2bbhYl2v5QAW2JRAsaM0g077OJYxjUoepWarrb8puk0zdGfZ92ER+a7jwmXudbFVzk22Vp/aliIMkbrouQXVrXQaWZq0H45XD3grC5Pgbjdbn/s7gfCXk6IsZNkc1ztkpluFGox7iZXIYsrWJDvnjMNuhs6KWQpymKD8VQaQU1AqnWOOCWmkqLOy7pXtf9XQS44I5KkUibNFc5vxDqZriNCAkVSYZbvhmEphRb2iWGEtTxrJtU61Gj+fVpu6wpEO0JgWZNqmJTXgIXiPYb9i//uuRnA8qVym+PBl2azkMrmRV7TFbyzes1S5P5aWq0SgcYPKDtb7c5zJUzZkvpqkGDvriLUO2qyZq5PIC1Ega/bzLQMj/Nd8OMaJZjjoTNDc8frqQ9j84Q1WYTt1mhkMJF4LjXTar45nomR2GjBWfrETQBCGmO4fKYyNctx4cg8arz7MwftPIEt6orDegQzu8HR5oCX0hBvzDwK96JGtT8vfC4LfhtftTtTO2VqIMZ7lPbHzgyIswSBcVc9B7VIPS4Zka8JEzO1CRzeoL9u6HWNsUnre/U+twyxNmkZ1ZQW1kjeet8PT6S7eVRJuMofQJwhP42gz3yve8LaDaOxihlmD+UHnBVpDGSYl2ieLr+TAh2uwBNhs0bdEHJFNfwvNg9ySXKs=
  file: webcounter
  skip_cleanup: true
  on:
    repo: allthingsclowd/web_page_counter
    tags: true
```
The deploy section, along with the encrypted deployment key, cab be generated automatically by using the [Travis CLI](https://github.com/travis-ci/travis.rb)

``` bash
travis setup releases
Detected repository as allthingsclowd/golang_web_page_counter, is this correct? |yes| no
Repository slug (owner/name): |allthingsclowd/golang_web_page_counter| allthingsclowd/web_page_counter
Username: allthingsclowd
Password for allthingsclowd: ********
Two-factor authentication code for allthingsclowd: 449740
File to Upload: webcounter
Deploy only from allthingsclowd/web_page_counter? |yes|
Encrypt API key? |yes|
```
## How long did it take?
60 minutes


