### PR TITLE
wip - Add Vault App-Role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 main
 .vault-token
 .provisioner-token
+.approle-id
+.secret-id
+.orchestrator-token

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
 - popd
 - bash scripts/install_consul.sh
 - bash scripts/install_vault.sh
+- bash scripts/configure_app_role.sh
 - sudo cp /home/travis/.vault-token /usr/local/bootstrap/.vault-token
 script:
 - source ./var.env

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,7 @@ Vagrant.configure("2") do |config|
     config.vm.define "leader01" do |leader01|
         leader01.vm.hostname = ENV['LEADER_NAME']
         leader01.vm.provision "shell", path: "scripts/install_nomad.sh", run: "always"
+        leader01.vm.provision "shell", path: "scripts/configure_app_role.sh", run: "always"
         leader01.vm.network "private_network", ip: ENV['LEADER_IP']
         leader01.vm.network "forwarded_port", guest: 8500, host: 8500
         leader01.vm.network "forwarded_port", guest: 8200, host: 8200

--- a/conf/envconsul.hcl
+++ b/conf/envconsul.hcl
@@ -1,5 +1,5 @@
   vault {
     address = "http://vault.service.consul:8200"
-    token   = "d4409a89-6224-f78c-f1d5-dac6d4f1f317"
+    token   = "81725d92-6ebb-cf01-5c12-57d7fd099bda"
     renew   = true
   }

--- a/conf/envconsul.hcl
+++ b/conf/envconsul.hcl
@@ -1,5 +1,5 @@
   vault {
     address = "http://vault.service.consul:8200"
-    token   = "9318a82a-7e2d-64fb-6314-e314dc51b28a"
+    token   = "d4409a89-6224-f78c-f1d5-dac6d4f1f317"
     renew   = true
   }

--- a/goapp-secret-id-login.json
+++ b/goapp-secret-id-login.json
@@ -1,0 +1,2 @@
+{
+"role_id": "84a3fd5d-201b-4aa9-f69b-a6a35d849e74", "secret_id": "0fe36a03-6299-8361-da1f-2ae859541648" }

--- a/main.go
+++ b/main.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
+	"encoding/json"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
+	"bytes"
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/go-redis/redis"
@@ -138,20 +140,15 @@ func getVaultKV(vaultKey string) string {
 		goapphealth = "NOTGOOD"
 	}
 
+	// Get the static approle id - this could be baked into a base image
 	appRoleIDFile, err := ioutil.ReadFile("/usr/local/bootstrap/.approle-id")
 	if err != nil {
 		fmt.Print(err)
 	}
 	appRoleID := string(appRoleIDFile)
-	fmt.Printf("App-Role ID Returned : >> %v \n", appRoleID)	
+	fmt.Printf("App-Role ID Returned : >> %v \n", appRoleID)
 
-	secretIDTokenFile, err := ioutil.ReadFile("/usr/local/bootstrap/.orchestrator-token")
-	if err != nil {
-		fmt.Print(err)
-	}
-	secretIDToken := string(secretIDTokenFile)
-	fmt.Printf("SecretID Token Returned : >> %v \n", secretIDToken)
-
+	// Get a provisioner token to generate a new secret -id ... this would usually occur in the orchestrator rather than the app???
 	vaultTokenFile, err := ioutil.ReadFile("/usr/local/bootstrap/.provisioner-token")
 	if err != nil {
 		fmt.Print(err)
@@ -159,6 +156,7 @@ func getVaultKV(vaultKey string) string {
 	vaultToken := string(vaultTokenFile)
 	fmt.Printf("Secret Token Returned : >> %v \n", vaultToken)
 
+	// Read in the Vault address from consul
 	vaultIP := getConsulKV(*consulClient, "LEADER_IP")
 	vaultAddress := "http://" + vaultIP + ":8200"
 	fmt.Printf("Secret Store Address : >> %v \n", vaultAddress)
@@ -172,8 +170,9 @@ func getVaultKV(vaultKey string) string {
 		return "FAIL"
 	}
 	
-	vaultClient.SetToken(secretIDToken)
+	vaultClient.SetToken(vaultToken)
 	
+	// Generate a new Vault Secret-ID
     resp, err := vaultClient.Logical().Write("/auth/approle/role/goapp/secret-id", nil)
     if err != nil {
 		fmt.Printf("Failed to get Secret ID >> %v \n", err)
@@ -184,32 +183,30 @@ func getVaultKV(vaultKey string) string {
 		return "Failed"
     }
 
-	
-
 	secretID := resp.Data["secret_id"].(string)
 	fmt.Printf("Secret ID Request Response : >> %v \n", secretID)
 
+	// Now using both the APP Role ID & the Secret ID generated above
 	data := map[string]interface{}{
         "role_id":   appRoleID,
-        "secret_id": secretID,
-    }
-    resp, err = vaultClient.Logical().Write("auth/approle/login", data)
-    if err != nil {
-		fmt.Printf("Failed to get VAULT client >> %v \n", err)
-		return "Failed"
-    }
-    if resp.Auth == nil {
-		fmt.Printf("Failed to get VAULT client >> %v \n", err)
-		return "Failed"
-    }
+		"secret_id": secretID,
+	}
 
-	fmt.Printf("Secret Token Request Response : >> %v \n", resp.Data)
+	fmt.Printf("Secret ID in map : >> %v \n", data)
+	
+	// Use the AppRole Login api call to get the application's Vault Token which will grant it access to the REDIS database credentials
+	appRoletokenResponse := queryVault(vaultAddress,"/v1/auth/approle/login","",data,"POST")
 
-	//vaultClient.SetToken(resp.Data["auth"])
+	appRoletoken := appRoletokenResponse["auth"].(map[string]interface{})["client_token"]
+
+	fmt.Printf("New API Secret Token Request Response : >> %v \n", appRoletoken)
+
+	vaultClient.SetToken(appRoletoken.(string))
 
 	completeKeyPath := "kv/development/" + vaultKey
 	fmt.Printf("Secret Key Path : >> %v \n", completeKeyPath)
 
+	// Read the Redis Credientials from VAULT
 	vaultSecret, err := vaultClient.Logical().Read(completeKeyPath)
 	if err != nil {
 		fmt.Printf("Failed to read VAULT key value %v - Please ensure the secret value exists in VAULT : e.g. vault kv get %v >> %v \n", vaultKey, completeKeyPath, err)
@@ -338,4 +335,41 @@ func incrementDataDogCounter(myNameSpace string, myTag string, myCounter string)
 	}
 
 	return true
+}
+
+func queryVault(vaultAddress string, url string, token string, data map[string]interface{}, action string) map[string]interface{} {
+	fmt.Println("\nDebug Vars Start")
+	fmt.Println("\nVAULT_ADDR:>", vaultAddress)
+	fmt.Println("\nURL:>", url)
+	fmt.Println("\nTOKEN:>", token)
+	fmt.Println("\nDATA:>", data)
+	fmt.Println("\nVERB:>", action)
+	fmt.Println("\nDebug Vars End")
+
+	apiCall := vaultAddress + url
+	bytesRepresentation, err := json.Marshal(data)
+
+	//var jsonStr = []byte(`{"title":"Buy cheese and bread for breakfast."}`)
+    req, err := http.NewRequest(action, apiCall, bytes.NewBuffer(bytesRepresentation))
+    req.Header.Set("X-Vault-Token", token)
+    req.Header.Set("Content-Type", "application/json")
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    if err != nil {
+        panic(err)
+    }
+    defer resp.Body.Close()
+
+    fmt.Println("response Status:", resp.Status)
+	fmt.Println("response Headers:", resp.Header)
+	
+	var result map[string]interface{}
+
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	fmt.Println("\n\nresponse result: ",result)
+	fmt.Println("\n\nresponse result .auth:",result["auth"].(map[string]interface{})["client_token"])
+
+	return result
 }

--- a/readme.md
+++ b/readme.md
@@ -104,8 +104,6 @@ $ curl localhost:8080
 
 ### New Features
 
-
-* __Add Vault App-Role to Application__ for Vault Access Method - demonstrates best practice of using centralised secret management vault - time est: 4hrs
 * Add DataDog event when crash occurs e.g. “app 8081 crashed” - provides enhance reporting metrics - time est:2hrs
 * Metrics: Consul KV versus Vault KV. Test with 100-1000 entries. Simple bash script timed - see if there's a significant overhead when using vault as a KV over Consul KV. - time est: 4hrs
 
@@ -174,8 +172,9 @@ $ curl localhost:8080
 * - modify vault installation to make binary accessable on all nodes
 * - install envconsul on all nodes
 * - auto-generate redis password on leader node and store in vault using vault client (binary)
-* - update redis installation to utilise envconsul to get redis password from vault
+* - update redis installation to utilise consul-template to get redis password from vault
 * - revert main.go application to consume vault v1 secrets (unversioned)
+* - Add Vault App-Role to Application__ for Vault Access Method - demonstrates best practice of using centralised secret management vault - time est: 4hrs
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,7 @@ $ curl localhost:8080
 ### New Features
 
 
-* Add Vault App-Role to Application for Vault Access Method - demonstrates best practice of using centralised secret management vault - time est: 4hrs
+* __Add Vault App-Role to Application__ for Vault Access Method - demonstrates best practice of using centralised secret management vault - time est: 4hrs
 * Add DataDog event when crash occurs e.g. “app 8081 crashed” - provides enhance reporting metrics - time est:2hrs
 * Metrics: Consul KV versus Vault KV. Test with 100-1000 entries. Simple bash script timed - see if there's a significant overhead when using vault as a KV over Consul KV. - time est: 4hrs
 

--- a/scripts/approle.json
+++ b/scripts/approle.json
@@ -1,0 +1,4 @@
+{
+  "type": "approle",
+  "description": "Demo AppRole auth backend for goapp webcounter deployment"
+}

--- a/scripts/audit-backend-file.json
+++ b/scripts/audit-backend-file.json
@@ -1,0 +1,6 @@
+{
+  "type": "file",
+  "options": {
+    "path": "/vagrant/logs/vault_audit_leader01.log"
+  }
+}

--- a/scripts/goapp-approle-role.json
+++ b/scripts/goapp-approle-role.json
@@ -1,0 +1,12 @@
+    {
+        "role_name": "goapp",
+        "bind_secret_id": true,
+        "secret_id_ttl": "24h",
+        "secret_id_num_uses": "0",
+        "token_ttl": "10m",
+        "token_max_ttl": "30m",
+        "period": 0,
+        "policies": [
+            "goapp-secret-read"
+        ]
+    }

--- a/scripts/goapp-secret-id-create.json
+++ b/scripts/goapp-secret-id-create.json
@@ -1,0 +1,1 @@
+{"policy":"path \"auth/approle/role/goapp/secret-id\" {capabilities = [\"read\", \"list\", \"create\", \"update\"]}"}

--- a/scripts/goapp-secret-id-login.json
+++ b/scripts/goapp-secret-id-login.json
@@ -1,0 +1,4 @@
+{
+  "role_id": "885ffef6-d669-07c3-aa4d-337ae3e1e398",
+  "secret_id": "ab17adff-bb94-2b54-c869-80da1e52c69f"
+}

--- a/scripts/goapp-secret-id-login.json
+++ b/scripts/goapp-secret-id-login.json
@@ -1,4 +1,4 @@
 {
-  "role_id": "885ffef6-d669-07c3-aa4d-337ae3e1e398",
-  "secret_id": "ab17adff-bb94-2b54-c869-80da1e52c69f"
+  "role_id": "84a3fd5d-201b-4aa9-f69b-a6a35d849e74",
+  "secret_id": "178d42e0-6b58-8829-eeb1-f7dfa044ee63"
 }

--- a/scripts/goapp-secret-id-token.json
+++ b/scripts/goapp-secret-id-token.json
@@ -1,0 +1,10 @@
+{
+  "policies": [
+    "goapp-secret-id-create"
+  ],
+  "metadata": {
+    "user": "Secret-Id Deployer"
+  },
+  "ttl": "1h",
+  "renewable": true
+}

--- a/scripts/goapp-secret-read.json
+++ b/scripts/goapp-secret-read.json
@@ -1,0 +1,1 @@
+{"policy":"path \"kv/development/redispassword\" {capabilities = [\"read\", \"list\"]}"}

--- a/scripts/install_consul.sh
+++ b/scripts/install_consul.sh
@@ -71,8 +71,6 @@ if [[ "${HOSTNAME}" =~ "leader" ]] || [ "${TRAVIS}" == "true" ]; then
     sudo cp /usr/local/bootstrap/conf/consul.d/redis.json /etc/consul.d/redis.json
     #SERVICE_DEFS_DIR="conf/consul.d"
     CONSUL_SCRIPTS="scripts"
-    # copy a consul service definition directory
-    # sudo cp -r ${SERVICE_DEFS_DIR} /etc
     # ensure all scripts are executable for consul health checks
     pushd ${CONSUL_SCRIPTS}
     for file in `ls`;
@@ -104,13 +102,5 @@ else
     sleep 10
   }
 fi
-    
-# NOTES to SELF
-# verifiy via api
-# root@godev01:~# curl http://localhost:8500/v1/kv/development/GO_DEV_IP | jq '.[]["Value"]' | base64 -di
-#
-# verify via cli
-# root@godev01:~# consul kv get development/GO_DEV_IP
-# 192.168.2.100
 
 echo consul started

--- a/scripts/install_redis.sh
+++ b/scripts/install_redis.sh
@@ -3,10 +3,10 @@ set -x
 
 source /usr/local/bootstrap/var.env
 
-# # Idempotency hack - if this file exists don't run the rest of the script
-# if [ -f "/var/vagrant_redis" ]; then
-#     exit 0
-# fi
+# Idempotency hack - if this file exists don't run the rest of the script
+if [ -f "/var/vagrant_redis" ]; then
+    exit 0
+fi
 
 # install this package in base image in the future
 which jq &>/dev/null || {

--- a/scripts/install_vault.sh
+++ b/scripts/install_vault.sh
@@ -91,14 +91,6 @@ EOF
   PROVISIONER_TOKEN=`sudo VAULT_ADDR="http://${IP}:8200" vault token create -policy=provisioner -field=token`
   sudo echo -n ${PROVISIONER_TOKEN} > /usr/local/bootstrap/.provisioner-token
   
-  # create admin & provisioner policies
-  tee /usr/local/bootstrap/conf/envconsul.hcl <<EOF
-  vault {
-    address = "http://vault.service.consul:8200"
-    token   = "${PROVISIONER_TOKEN}"
-    renew   = true
-  }
-EOF
   sudo chmod ugo+r /usr/local/bootstrap/.provisioner-token
 
   tee admin_policy.hcl <<EOF
@@ -160,7 +152,5 @@ EOF
   sudo VAULT_ADDR="http://${IP}:8200" vault login ${ADMIN_TOKEN}
   sudo VAULT_ADDR="http://${IP}:8200" vault policy list
   sudo VAULT_ADDR="http://${IP}:8200" vault kv put kv/development/redispassword value=${REDIS_MASTER_PASSWORD}
-  # sudo VAULT_ADDR="http://${IP}:8200" vault login ${PROVISIONER_TOKEN}
-  # sudo VAULT_ADDR="http://${IP}:8200" vault policy list
-  # sudo VAULT_ADDR="http://${IP}:8200" vault kv get secret/development/REDIS_MASTER_PASSWORD
+
 fi

--- a/scripts/secret_id_config.json
+++ b/scripts/secret_id_config.json
@@ -1,0 +1,3 @@
+{
+  "metadata": "{ \"tag1\": \"goapp production\" }"
+}

--- a/scripts/travis_run_go_app.sh
+++ b/scripts/travis_run_go_app.sh
@@ -7,6 +7,9 @@ go get ./...
 go build -o webcounter main.go
 ./webcounter &
 
+# delay added to allow webcounter startup
+sleep 3
+
 page_hit_counter=`lynx --dump http://localhost:8080 | awk 'FNR==3{ print $1 }'`
 echo $page_hit_counter
 next_page_hit_counter=`lynx --dump http://localhost:8080 | awk 'FNR==3{ print $1 }'`


### PR DESCRIPTION
# Why is the PR required?

### New Feature:
Use App-Role to deliver token to application

## What does this PR do?
(Implements Vault's App-Role feature)[https://www.vaultproject.io/docs/auth/approle.html]

## How was this PR implemented?

When Vault in installed a new provisioner role is created as it's not recommended to use vault root token.

__install_vault.sh__

``` bash
 # create admin & provisioner policies
  tee provisioner_policy.hcl <<EOF
  # Manage auth methods broadly across Vault
  path "auth/*"
  {
    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
  }

  # List, create, update, and delete auth methods
  path "sys/auth/*"
  {
    capabilities = ["create", "read", "update", "delete", "sudo"]
  }

  # List existing policies
  path "sys/policy"
  {
    capabilities = ["read"]
  }

  # Create and manage ACL policies
  path "sys/policy/*"
  {
    capabilities = ["create", "read", "update", "delete", "list"]
  }

  # List, create, update, and delete key/value secrets
  path "secret/*"
  {
    capabilities = ["create", "read", "update", "delete", "list"]
  }

  # List, create, update, and delete key/value secrets
  path "kv/*"
  {
    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
  }
EOF
  sudo VAULT_ADDR="http://${IP}:8200" vault policy write provisioner provisioner_policy.hcl

  PROVISIONER_TOKEN=`sudo VAULT_ADDR="http://${IP}:8200" vault token create -policy=provisioner -field=token`
  sudo echo -n ${PROVISIONER_TOKEN} > /usr/local/bootstrap/.provisioner-token
  
  sudo chmod ugo+r /usr/local/bootstrap/.provisioner-token

  tee admin_policy.hcl <<EOF
  # Manage auth methods broadly across Vault
  path "auth/*"
  {
    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
  }

  # List, create, update, and delete auth methods
  path "sys/auth/*"
  {
    capabilities = ["create", "read", "update", "delete", "sudo"]
  }

  # List existing policies
  path "sys/policy"
  {
    capabilities = ["read"]
  }

  # Create and manage ACL policies broadly across Vault
  path "sys/policy/*"
  {
    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
  }

  # List, create, update, and delete key/value secrets
  path "secret/*"
  {
    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
  }

  # List, create, update, and delete key/value secrets
  path "kv/*"
  {
    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
  }

  # Manage and manage secret engines broadly across Vault.
  path "sys/mounts/*"
  {
    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
  }

  # Read health checks
  path "sys/health"
  {
    capabilities = ["read", "sudo"]
  }
EOF
  sudo VAULT_ADDR="http://${IP}:8200" vault policy write admin admin_policy.hcl
  
  ADMIN_TOKEN=`sudo VAULT_ADDR="http://${IP}:8200" vault token create -policy=admin -field=token`
```
This new provisioner role is used to create the AppRole policy, enable the AppRole backend and get the AppRole ID

__configure_app_role.sh__

``` bash
##--------------------------------------------------------------------
## Create ACL Policy

# Policy to apply to AppRole token
tee goapp-secret-read.json <<EOF
{"policy":"path \"kv/development/redispassword\" {capabilities = [\"read\", \"list\"]}"}
EOF

# Write the policy
curl \
    --location \
    --header "X-Vault-Token: ${VAULT_TOKEN}" \
    --request PUT \
    --data @goapp-secret-read.json \
    ${VAULT_ADDR}/v1/sys/policy/goapp-secret-read | jq .

##--------------------------------------------------------------------

# List ACL policies
curl \
    --location \
    --header "X-Vault-Token: ${VAULT_TOKEN}" \
    --request LIST \
    ${VAULT_ADDR}/v1/sys/policy | jq .

##--------------------------------------------------------------------
## Enable & Configure AppRole Auth Backend

# AppRole auth backend config
tee approle.json <<EOF
{
  "type": "approle",
  "description": "Demo AppRole auth backend for goapp webcounter deployment"
}
EOF

# Create the approle backend
curl \
    --location \
    --header "X-Vault-Token: ${VAULT_TOKEN}" \
    --request POST \
    --data @approle.json \
    ${VAULT_ADDR}/v1/sys/auth/approle | jq .

# Check if AppRole Exists
APPROLEID=`curl  \
   --header "X-Vault-Token: ${VAULT_TOKEN}" \
   ${VAULT_ADDR}/v1/auth/approle/role/goapp/role-id | jq -r .data.role_id`

if [ "${APPROLEID}" == null ]; then
    # AppRole backend configuration
    tee goapp-approle-role.json <<EOF
    {
        "role_name": "goapp",
        "bind_secret_id": true,
        "secret_id_ttl": "24h",
        "secret_id_num_uses": "0",
        "token_ttl": "10m",
        "token_max_ttl": "30m",
        "period": 0,
        "policies": [
            "goapp-secret-read"
        ]
    }
EOF

    # Create the AppRole role
    curl \
        --location \
        --header "X-Vault-Token: ${VAULT_TOKEN}" \
        --request POST \
        --data @goapp-approle-role.json \
        ${VAULT_ADDR}/v1/auth/approle/role/goapp | jq .

    APPROLEID=`curl  \
   --header "X-Vault-Token: ${VAULT_TOKEN}" \
   ${VAULT_ADDR}/v1/auth/approle/role/goapp/role-id | jq -r .data.role_id`

fi

echo -e "\n\nApplication RoleID = ${APPROLEID}\n\n"
echo -n ${APPROLEID} > /usr/local/bootstrap/.approle-id

```

The approle-id generated above could be baked into your application, base image or supplied by the application architect. In this case we simply read it from a file for the demo.

The application also needs a secret id to combine with this approle-id to get a token. Again this would typically be created outside the application possibly by the config manager or orchestrator - eg Kubernetes, Ansible, Chef, Terraform, Nomad etc.
Again in this case I generate the secret-id within the application (should be the orchestrator) and passed to the application.

With both the app-role id and the secret-id the application is able to make an unauthenticated call to Vault to obtain a token that grants it access to the Redis Database Credentials

Vault golang functions in __main.go__

``` go
func getVaultKV(vaultKey string) string {

	// Get a new Consul client
	consulClient, err := consul.NewClient(consul.DefaultConfig())
	if err != nil {
		fmt.Printf("Failed to contact consul - Please ensure both local agent and remote server are running : e.g. consul members >> %v \n", err)
		goapphealth = "NOTGOOD"
	}

	// Get the static approle id - this could be baked into a base image
	appRoleIDFile, err := ioutil.ReadFile("/usr/local/bootstrap/.approle-id")
	if err != nil {
		fmt.Print(err)
	}
	appRoleID := string(appRoleIDFile)
	fmt.Printf("App-Role ID Returned : >> %v \n", appRoleID)

	// Get a provisioner token to generate a new secret -id ... this would usually occur in the orchestrator rather than the app???
	vaultTokenFile, err := ioutil.ReadFile("/usr/local/bootstrap/.provisioner-token")
	if err != nil {
		fmt.Print(err)
	}
	vaultToken := string(vaultTokenFile)
	fmt.Printf("Secret Token Returned : >> %v \n", vaultToken)

	// Read in the Vault address from consul
	vaultIP := getConsulKV(*consulClient, "LEADER_IP")
	vaultAddress := "http://" + vaultIP + ":8200"
	fmt.Printf("Secret Store Address : >> %v \n", vaultAddress)

	// Get a handle to the Vault Secret KV API
	vaultClient, err := vault.NewClient(&vault.Config{
		Address: vaultAddress,
	})
	if err != nil {
		fmt.Printf("Failed to get VAULT client >> %v \n", err)
		return "FAIL"
	}
	
	vaultClient.SetToken(vaultToken)
	
	// Generate a new Vault Secret-ID
    resp, err := vaultClient.Logical().Write("/auth/approle/role/goapp/secret-id", nil)
    if err != nil {
		fmt.Printf("Failed to get Secret ID >> %v \n", err)
		return "Failed"
    }
    if resp == nil {
		fmt.Printf("Failed to get Secfret ID >> %v \n", err)
		return "Failed"
    }

	secretID := resp.Data["secret_id"].(string)
	fmt.Printf("Secret ID Request Response : >> %v \n", secretID)

	// Now using both the APP Role ID & the Secret ID generated above
	data := map[string]interface{}{
        "role_id":   appRoleID,
		"secret_id": secretID,
	}

	fmt.Printf("Secret ID in map : >> %v \n", data)
	
	// Use the AppRole Login api call to get the application's Vault Token which will grant it access to the REDIS database credentials
	appRoletokenResponse := queryVault(vaultAddress,"/v1/auth/approle/login","",data,"POST")

	appRoletoken := appRoletokenResponse["auth"].(map[string]interface{})["client_token"]

	fmt.Printf("New API Secret Token Request Response : >> %v \n", appRoletoken)

	vaultClient.SetToken(appRoletoken.(string))

	completeKeyPath := "kv/development/" + vaultKey
	fmt.Printf("Secret Key Path : >> %v \n", completeKeyPath)

	// Read the Redis Credientials from VAULT
	vaultSecret, err := vaultClient.Logical().Read(completeKeyPath)
	if err != nil {
		fmt.Printf("Failed to read VAULT key value %v - Please ensure the secret value exists in VAULT : e.g. vault kv get %v >> %v \n", vaultKey, completeKeyPath, err)
		return "FAIL"
	}
	fmt.Printf("Secret Returned : >> %v \n", vaultSecret.Data["value"])
	result := vaultSecret.Data["value"]
	fmt.Printf("Secret Result Returned : >> %v \n", result.(string))
	return result.(string)
}
```

``` go
func queryVault(vaultAddress string, url string, token string, data map[string]interface{}, action string) map[string]interface{} {
	fmt.Println("\nDebug Vars Start")
	fmt.Println("\nVAULT_ADDR:>", vaultAddress)
	fmt.Println("\nURL:>", url)
	fmt.Println("\nTOKEN:>", token)
	fmt.Println("\nDATA:>", data)
	fmt.Println("\nVERB:>", action)
	fmt.Println("\nDebug Vars End")

	apiCall := vaultAddress + url
	bytesRepresentation, err := json.Marshal(data)

	//var jsonStr = []byte(`{"title":"Buy cheese and bread for breakfast."}`)
    req, err := http.NewRequest(action, apiCall, bytes.NewBuffer(bytesRepresentation))
    req.Header.Set("X-Vault-Token", token)
    req.Header.Set("Content-Type", "application/json")

    client := &http.Client{}
    resp, err := client.Do(req)
    if err != nil {
        panic(err)
    }
    defer resp.Body.Close()

    fmt.Println("response Status:", resp.Status)
	fmt.Println("response Headers:", resp.Header)
	
	var result map[string]interface{}

	json.NewDecoder(resp.Body).Decode(&result)

	fmt.Println("\n\nresponse result: ",result)
	fmt.Println("\n\nresponse result .auth:",result["auth"].(map[string]interface{})["client_token"])

	return result
}
```


## How long did it take?
10 hours


