### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ $ curl localhost:8080
 
 ### New Features
 
-* Add DataDog event when crash occurs e.g. “app 8081 crashed” - provides enhance reporting metrics - time est:2hrs
+* __Add__ DataDog event when crash occurs e.g. “app 8081 crashed” - provides enhance reporting metrics - time est:2hrs
 * Metrics: Consul KV versus Vault KV. Test with 100-1000 entries. Simple bash script timed - see if there's a significant overhead when using vault as a KV over Consul KV. - time est: 4hrs
 
 ## Done


### PR DESCRIPTION
# Why is the PR required?

### New Feature:
Add DataDog event when crash occurs e.g. “app 8081 crashed” 
![image](https://user-images.githubusercontent.com/9472095/43784033-11d58e1e-9a5b-11e8-8358-db0f354974c4.png)

## What does this PR do?
provides enhance reporting metrics

## How was this PR implemented?
``` go
func crashHandler(w http.ResponseWriter, r *http.Request) {
	
	goapphealth = "FORCEDCRASH"
	fmt.Printf("You Killed Me!!!!!! Application Status: %v \n", goapphealth)
	dataDog := sendDataDogEvent("WebCounter Crashed", targetPort)
	if !dataDog {
		fmt.Printf("Failed to send datadog event.")
	}
	// added delay to ensure event is sent before process terminates
	time.Sleep(2 * time.Second)
	os.Exit(1)

}
```

``` go
// SendDataDogEvent 
func sendDataDogEvent(title string, eventMessage string) bool {
	// get a pointer to the datadog agent
	ddClient, err := statsd.New("127.0.0.1:8125")
	defer ddClient.Close()
	if err != nil {
		fmt.Printf("Failed to contact DataDog Agent: %v. Check the DataDog agent is installed and running \n", err)
		return false
	}

	// send event message
	err = ddClient.SimpleEvent(title, eventMessage)
	// prefix every metric with the app name
	if err != nil {
		fmt.Printf("Failed to send new event to DataDog Agent: %v. Check the DataDog agent is installed and running \n", err)
		return false
	}
	
	return true
}
```

## How long did it take?
1 hr


