### PR TITLE
Fix intermitent Travis-CI failures

### DIFF
--- a/conf/master.redis.ctpl
+++ b/conf/master.redis.ctpl
@@ -88,7 +88,7 @@ aof-rewrite-incremental-fsync yes
 maxmemory-policy noeviction
 
 # Ensure Redis only listens on the local host when configuring Consul connect
-#bind 127.0.0.1
+bind 127.0.0.1
 
 # Consul-Template is used in the redis file at deployment time
 # It reads the password from Vault and inserts it into this file

--- a/conf/master.redis.ctpl
+++ b/conf/master.redis.ctpl
@@ -87,6 +87,9 @@ hz 10
 aof-rewrite-incremental-fsync yes
 maxmemory-policy noeviction
 
+# Ensure Redis only listens on the local host when configuring Consul connect
+bind 127.0.0.1
+
 # Consul-Template is used in the redis file at deployment time
 # It reads the password from Vault and inserts it into this file
 {{- with secret "kv/development/redispassword" }}

--- a/conf/master.redis.ctpl
+++ b/conf/master.redis.ctpl
@@ -88,7 +88,7 @@ aof-rewrite-incremental-fsync yes
 maxmemory-policy noeviction
 
 # Ensure Redis only listens on the local host when configuring Consul connect
-bind 127.0.0.1
+#bind 127.0.0.1
 
 # Consul-Template is used in the redis file at deployment time
 # It reads the password from Vault and inserts it into this file

--- a/scripts/install_SecretID_Factory.sh
+++ b/scripts/install_SecretID_Factory.sh
@@ -77,9 +77,13 @@ fi
 
 sudo killall VaultServiceIDFactory &>/dev/null
 
-# check VaultServiceIDFactory binary
-[ -f /usr/local/bin/VaultServiceIDFactory ] &>/dev/null || {
+# Added loop below to overcome Travis-CI download issue
+RETRYDOWNLOAD="1"
+
+while [ ${RETRYDOWNLOAD} -lt 5 ] && [ ! -f /usr/local/bin/VaultServiceIDFactory ]
+do
     pushd /usr/local/bin
+    echo 'Vault SecretID Service Download - Take ${RETRYDOWNLOAD}' 
     # download binary and template file from latest release
     sudo bash -c 'curl -s https://api.github.com/repos/allthingsclowd/VaultServiceIDFactory/releases/latest \
     | grep "browser_download_url" \
@@ -87,6 +91,13 @@ sudo killall VaultServiceIDFactory &>/dev/null
     | tr -d \" | wget -i - '
     sudo chmod +x VaultServiceIDFactory
     popd
+    RETRYDOWNLOAD=$[${RETRYDOWNLOAD}+1]
+    sleep 5
+done
+
+[  -f /usr/local/bin/VaultServiceIDFactory  ] &>/dev/null || {
+     echo 'Failed to download Vault Secret ID Factory Service'
+     exit 1
 }
 
 #sudo /usr/local/bin/VaultServiceIDFactory -vault="http://${IP}:8200" &> ${LOG} &

--- a/scripts/travis_run_go_app.sh
+++ b/scripts/travis_run_go_app.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # delayed added to ensure consul has started on host - intermittent failures
-sleep 5
+sleep 10
 
 
 go get ./...
@@ -9,7 +9,7 @@ go build -o webcounter main.go
 ./webcounter &
 
 # delay added to allow webcounter startup
-sleep 3
+sleep 10
 
 page_hit_counter=`lynx --dump http://localhost:8080 | awk 'FNR==3{ print $1 }'`
 echo $page_hit_counter

--- a/scripts/travis_run_go_app.sh
+++ b/scripts/travis_run_go_app.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -x
 
 # delayed added to ensure consul has started on host - intermittent failures
-sleep 10
+sleep 20
 
 
 go get ./...
@@ -9,7 +10,7 @@ go build -o webcounter main.go
 ./webcounter &
 
 # delay added to allow webcounter startup
-sleep 10
+sleep 20
 
 page_hit_counter=`lynx --dump http://localhost:8080 | awk 'FNR==3{ print $1 }'`
 echo $page_hit_counter

--- a/scripts/travis_run_go_app.sh
+++ b/scripts/travis_run_go_app.sh
@@ -2,7 +2,7 @@
 set -x
 
 # delayed added to ensure consul has started on host - intermittent failures
-sleep 20
+sleep 5
 
 
 go get ./...
@@ -10,7 +10,7 @@ go build -o webcounter main.go
 ./webcounter &
 
 # delay added to allow webcounter startup
-sleep 20
+sleep 5
 
 page_hit_counter=`lynx --dump http://localhost:8080 | awk 'FNR==3{ print $1 }'`
 echo $page_hit_counter


### PR DESCRIPTION
# Why is the PR required?

### Issue:

Travis-CI tests fail intermittently due to the factory service not being available to download on first attempt. Some internal issue with Travis-CI???

## What does this PR do?

Implements a retry loop to download the factory service app during setup

## How was this PR implemented?
```
# Added loop below to overcome Travis-CI download issue
RETRYDOWNLOAD="1"

while [ ${RETRYDOWNLOAD} -lt 5 ] && [ ! -f /usr/local/bin/VaultServiceIDFactory ]
do
    pushd /usr/local/bin
    echo 'Vault SecretID Service Download - Take ${RETRYDOWNLOAD}' 
    # download binary and template file from latest release
    sudo bash -c 'curl -s https://api.github.com/repos/allthingsclowd/VaultServiceIDFactory/releases/latest \
    | grep "browser_download_url" \
    | cut -d : -f 2,3 \
    | tr -d \" | wget -i - '
    sudo chmod +x VaultServiceIDFactory
    popd
    RETRYDOWNLOAD=$[${RETRYDOWNLOAD}+1]
    sleep 5
done

[  -f /usr/local/bin/VaultServiceIDFactory  ] &>/dev/null || {
     echo 'Failed to download Vault Secret ID Factory Service'
     exit 1
}
```

## How long did it take?

60 minutes

