### PR TITLE
Disable cache on services

### DIFF
--- a/conf/nginx.ctpl
+++ b/conf/nginx.ctpl
@@ -8,6 +8,8 @@ server {
  listen 9090 default_server;
 
  location / {
+   add_header 'Cache-Control' 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+   expires off;
    proxy_pass http://goapp;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header Host $host;


### PR DESCRIPTION
# Why is the PR required?

To tell browser to not cache, and make more cool demos.

## What does this PR do?

Update nginx.ctpl




