### PR TITLE
added encryption key to env.vars file

### DIFF
--- a/scripts/install_consul.sh
+++ b/scripts/install_consul.sh
@@ -39,7 +39,7 @@ setup_environment () {
   CIDR=`ip addr show ${IFACE} | awk '$2 ~ "192.168.9" {print $2}'`
   IP=${CIDR%%/24}
   
-  export ConsulKeygenOutput=`/usr/local/bin/consul keygen`
+  # export ConsulKeygenOutput=`/usr/local/bin/consul keygen` [e.g. mUIJq6TITeenfVa2yMSi6yLwxrz2AYcC0dXissYpOxE=]
 
   if [ -d /vagrant ]; then
     LOG="/vagrant/logs/consul_${HOSTNAME}.log"

--- a/var.env
+++ b/var.env
@@ -26,3 +26,5 @@ export LEADER_NAME=leader01.vagrant.local
 export LEADER_IP=192.168.9.11
 #export DNSNAME=192.168.86.27
 export DNSNAME=192.168.9.250
+# Consul UDP Encryption Key - please don't bootstrap your production platforms this way - this is just a demo env 
+export ConsulKeygenOutput=mUIJq6TITeenfVa2yMSi6yLwxrz2AYcC0dXissYpOxE=


### PR DESCRIPTION
# Why is the PR required?

### Issue:

Consul encryption key needs to be created outside of the individual node deployments

## What does this PR do?

Fixes scalability issue with Consul UDP encryption. Currently designed for single node deployments.

## How was this PR implemented?

Moved `consul keygen` output to env.var  file

## How long did it take?

5 minutes

