### PR TITLE
Move 2 envoy

### DIFF
--- a/conf/nomad.d/client.hcl
+++ b/conf/nomad.d/client.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "244d2ca0-0db1-739c-1331-c300372012b9"
+  token = "2e70f801-bfb2-0816-0da1-8baf9e403e54"
   }
 
 datacenter = "hashistack1"

--- a/conf/nomad.d/client.hcl
+++ b/conf/nomad.d/client.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "2e70f801-bfb2-0816-0da1-8baf9e403e54"
+  token = "c47a237c-be96-87ec-eaee-03e7b5643eea"
   }
 
 datacenter = "hashistack1"

--- a/conf/nomad.d/client.hcl
+++ b/conf/nomad.d/client.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "af2b522c-b5b6-a92c-f759-6fa2a94f092a"
+  token = "a20c64e7-e55c-3a1b-a807-081005a35a85"
   }
 
 datacenter = "hashistack1"

--- a/conf/nomad.d/client.hcl
+++ b/conf/nomad.d/client.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "d0cea87a-911f-073d-bad6-1b222ae98bb5"
+  token = "983111ca-5d80-f35b-2830-5f7e31f253bf"
   }
 
 datacenter = "hashistack1"

--- a/conf/nomad.d/client.hcl
+++ b/conf/nomad.d/client.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "983111ca-5d80-f35b-2830-5f7e31f253bf"
+  token = "244d2ca0-0db1-739c-1331-c300372012b9"
   }
 
 datacenter = "hashistack1"

--- a/conf/nomad.d/client.hcl
+++ b/conf/nomad.d/client.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "24fb1f8d-eb4e-7db5-ddbf-c5bb30b3bb78"
+  token = "2f1caa4f-b3e5-32e4-5dab-feedf3c480d9"
   }
 
 datacenter = "hashistack1"

--- a/conf/nomad.d/client.hcl
+++ b/conf/nomad.d/client.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "c47a237c-be96-87ec-eaee-03e7b5643eea"
+  token = "24fb1f8d-eb4e-7db5-ddbf-c5bb30b3bb78"
   }
 
 datacenter = "hashistack1"

--- a/conf/nomad.d/client.hcl
+++ b/conf/nomad.d/client.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "2f1caa4f-b3e5-32e4-5dab-feedf3c480d9"
+  token = "af2b522c-b5b6-a92c-f759-6fa2a94f092a"
   }
 
 datacenter = "hashistack1"

--- a/conf/nomad.d/nomad.hcl
+++ b/conf/nomad.d/nomad.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "2e70f801-bfb2-0816-0da1-8baf9e403e54"
+  token = "c47a237c-be96-87ec-eaee-03e7b5643eea"
   }
 
 # Increase log verbosity

--- a/conf/nomad.d/nomad.hcl
+++ b/conf/nomad.d/nomad.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "d0cea87a-911f-073d-bad6-1b222ae98bb5"
+  token = "62edd4d4-5910-6377-7e6c-8be93956b185"
   }
 
 # Increase log verbosity

--- a/conf/nomad.d/nomad.hcl
+++ b/conf/nomad.d/nomad.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "24fb1f8d-eb4e-7db5-ddbf-c5bb30b3bb78"
+  token = "2f1caa4f-b3e5-32e4-5dab-feedf3c480d9"
   }
 
 # Increase log verbosity

--- a/conf/nomad.d/nomad.hcl
+++ b/conf/nomad.d/nomad.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "2f1caa4f-b3e5-32e4-5dab-feedf3c480d9"
+  token = "af2b522c-b5b6-a92c-f759-6fa2a94f092a"
   }
 
 # Increase log verbosity

--- a/conf/nomad.d/nomad.hcl
+++ b/conf/nomad.d/nomad.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "c47a237c-be96-87ec-eaee-03e7b5643eea"
+  token = "24fb1f8d-eb4e-7db5-ddbf-c5bb30b3bb78"
   }
 
 # Increase log verbosity

--- a/conf/nomad.d/nomad.hcl
+++ b/conf/nomad.d/nomad.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "62edd4d4-5910-6377-7e6c-8be93956b185"
+  token = "244d2ca0-0db1-739c-1331-c300372012b9"
   }
 
 # Increase log verbosity

--- a/conf/nomad.d/nomad.hcl
+++ b/conf/nomad.d/nomad.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "af2b522c-b5b6-a92c-f759-6fa2a94f092a"
+  token = "a20c64e7-e55c-3a1b-a807-081005a35a85"
   }
 
 # Increase log verbosity

--- a/conf/nomad.d/nomad.hcl
+++ b/conf/nomad.d/nomad.hcl
@@ -4,7 +4,7 @@ consul {
   ca_file   = "/etc/ssl/certs/consul-agent-ca.pem"
   cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
   key_file  = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-  token = "244d2ca0-0db1-739c-1331-c300372012b9"
+  token = "2e70f801-bfb2-0816-0da1-8baf9e403e54"
   }
 
 # Increase log verbosity

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -5,7 +5,7 @@
     tls_ca_file = "/etc/ssl/certs/consul-agent-ca.pem"
     tls_cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
     tls_key_file = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-    token = "ddceced4-c5a5-8640-4fda-d3d003dadea2"
+    token = "91e4dea2-3768-4476-36d5-695403111fe5"
   }
 
   ui = true

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -5,7 +5,7 @@
     tls_ca_file = "/etc/ssl/certs/consul-agent-ca.pem"
     tls_cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
     tls_key_file = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-    token = "a366865e-b838-6d4f-66c2-713f88862c07"
+    token = "3e963fe9-80c6-469a-815d-f52be92c8fd6"
   }
 
   ui = true

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -5,7 +5,7 @@
     tls_ca_file = "/etc/ssl/certs/consul-agent-ca.pem"
     tls_cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
     tls_key_file = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-    token = "dd24d668-d69f-4f81-e77f-63e49fa26a91"
+    token = "6302bc03-1baf-e255-9abe-10329fcf2b2f"
   }
 
   ui = true

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -5,7 +5,7 @@
     tls_ca_file = "/etc/ssl/certs/consul-agent-ca.pem"
     tls_cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
     tls_key_file = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-    token = "18150a00-eb2a-0d00-0b20-8a15a5b49a40"
+    token = "f53dc001-2252-7f48-90c0-77d6f65c3b37"
   }
 
   ui = true

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -5,7 +5,7 @@
     tls_ca_file = "/etc/ssl/certs/consul-agent-ca.pem"
     tls_cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
     tls_key_file = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-    token = "6302bc03-1baf-e255-9abe-10329fcf2b2f"
+    token = "ddceced4-c5a5-8640-4fda-d3d003dadea2"
   }
 
   ui = true

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -5,7 +5,7 @@
     tls_ca_file = "/etc/ssl/certs/consul-agent-ca.pem"
     tls_cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
     tls_key_file = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-    token = "f53dc001-2252-7f48-90c0-77d6f65c3b37"
+    token = "a366865e-b838-6d4f-66c2-713f88862c07"
   }
 
   ui = true

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -5,7 +5,7 @@
     tls_ca_file = "/etc/ssl/certs/consul-agent-ca.pem"
     tls_cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
     tls_key_file = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-    token = "91e4dea2-3768-4476-36d5-695403111fe5"
+    token = "b308d2a7-92c3-f3ea-8843-1735f03096be"
   }
 
   ui = true

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -5,7 +5,7 @@
     tls_ca_file = "/etc/ssl/certs/consul-agent-ca.pem"
     tls_cert_file = "/etc/consul.d/pki/tls/certs/consul-client.pem"
     tls_key_file = "/etc/consul.d/pki/tls/private/consul-client-key.pem"
-    token = "b308d2a7-92c3-f3ea-8843-1735f03096be"
+    token = "18150a00-eb2a-0d00-0b20-8a15a5b49a40"
   }
 
   ui = true

--- a/scripts/install_SecretID_Factory.sh
+++ b/scripts/install_SecretID_Factory.sh
@@ -263,7 +263,7 @@ install_secret_id_application () {
     sleep 15
 
     # start envoy proxy
-    sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh  approle "\"App Role Vault Secret ID Factory\"" approle 19002 ${CONSUL_HTTP_TOKEN}
+    sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh  approle "App Role Vault Secret ID Factory "-sidecar-for approle" 19002 ${CONSUL_HTTP_TOKEN}
     sleep 5
 
     curl http://127.0.0.1:8314/health 

--- a/scripts/install_SecretID_Factory.sh
+++ b/scripts/install_SecretID_Factory.sh
@@ -8,6 +8,7 @@ register_secret_id_service_with_consul () {
     tee secretid_service.json <<EOF
     {
       "Name": "approle",
+      "Id": "approle",
       "Tags": [
         "approle",
         "secret-id"
@@ -87,6 +88,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
+Type=simple
 User=${1}
 Group=${1}
 PIDFile=/var/run/${1}/${1}.pid
@@ -209,7 +211,7 @@ setup_environment () {
 
 }
 
-install_go_application () {
+install_secret_id_application () {
     
     sudo killall VaultServiceIDFactory &>/dev/null
 
@@ -257,16 +259,18 @@ install_go_application () {
     fi
 
 
-    # start connect application proxy
-    sleep 5
-    start_envoy_proxy_service approle "App Role Vault Secret ID Factory" approle 19002
+
+    sleep 15
+
+    # start envoy proxy
+    sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh  approle "\"App Role Vault Secret ID Factory\"" approle 19002 ${CONSUL_HTTP_TOKEN}
     sleep 5
 
     curl http://127.0.0.1:8314/health 
 
 }
 
-verify_go_application () {
+verify_go_application () {                                                                         
 
     if [ "${TRAVIS}" == "true" ]; then
 
@@ -409,7 +413,8 @@ EOF
 set -x
 echo 'Start of Factory Service Installation'
 setup_environment
-install_go_application
+install_secret_id_application
+# install_go_application
 #verify_go_application
 
 # initialise the factory service with the provisioner token

--- a/scripts/install_SecretID_Factory.sh
+++ b/scripts/install_SecretID_Factory.sh
@@ -425,8 +425,8 @@ curl --header 'Content-Type: application/json' \
     --data "{\"token\":\""${WRAPPED_TOKEN}"\"}" \
     http://127.0.0.1:8314/initialiseme
 
-echo 'Debug - Aliased check "Factory Service SecretID" failing:'
-sleep 30
+# echo 'Debug - Aliased check "Factory Service SecretID" failing:'
+# sleep 30
 
 register_secret_id_service_with_consul
 

--- a/scripts/install_SecretID_Factory.sh
+++ b/scripts/install_SecretID_Factory.sh
@@ -121,31 +121,25 @@ create_service_user () {
 
 }
 
-start_app_proxy_service () {
+start_envoy_proxy_service () {
   # start the new service mesh proxy for the application
   # param 1 ${1}: app-proxy name
   # param 2 ${2}: app-proxy service description
+  # param 3 ${3}: consul host service name
+  # param 4 ${4}: envoy proxy admin port needs to be different if running multiple instances on same host network
 
-  create_service "${1}" "${2}" "/usr/local/bin/consul connect proxy -http-addr=https://127.0.0.1:8321 -ca-file=/${ROOTCERTPATH}/ssl/certs/consul-agent-ca.pem -client-cert=/${ROOTCERTPATH}/consul.d/pki/tls/certs/consul-client.pem -client-key=/${ROOTCERTPATH}/consul.d/pki/tls/private/consul-client-key.pem -token=${AGENTTOKEN} -sidecar-for ${1}"
+  create_service "${1}" "${2}" "/usr/local/bin/consul connect envoy \
+                                                        -http-addr=https://127.0.0.1:8321 \
+                                                        -ca-file=/${ROOTCERTPATH}/ssl/certs/consul-agent-ca.pem \
+                                                        -client-cert=/${ROOTCERTPATH}/consul.d/pki/tls/certs/consul-client.pem \
+                                                        -client-key=/${ROOTCERTPATH}/consul.d/pki/tls/private/consul-client-key.pem \
+                                                        -token=${CONSUL_HTTP_TOKEN} \
+                                                        -sidecar-for ${3} \
+                                                        -admin-bind localhost:${4}"
   sudo usermod -a -G webpagecountercerts ${1}
   sudo systemctl start ${1}
   #sudo systemctl status ${1}
   echo "${1} Proxy App Service Build Complete"
-}
-
-start_client_proxy_service () {
-    # start the new service mesh proxy for the client
-    # param 1 ${1}: client-proxy name
-    # param 2 ${2}: client-proxy service description
-    # param 3 ${3}: client-proxy upstream consul service name
-    # param 4 ${4}: client-proxy local service port number
-    
-
-    create_service "${1}" "${2}" "/usr/local/bin/consul connect proxy -http-addr=https://127.0.0.1:8321 -ca-file=/${ROOTCERTPATH}/ssl/certs/consul-agent-ca.pem -client-cert=/${ROOTCERTPATH}/consul.d/pki/tls/certs/consul-client.pem -client-key=/${ROOTCERTPATH}/consul.d/pki/tls/private/consul-client-key.pem -token=${AGENTTOKEN} -service ${1} -upstream ${3}:${4}"
-    sudo usermod -a -G webpagecountercerts ${1}
-    sudo systemctl start ${1}
-    #sudo systemctl status ${1}
-    echo "${1} Proxy Client Service Build Complete"
 }
 
 
@@ -195,6 +189,8 @@ setup_environment () {
     export CONSUL_CACERT=/${ROOTCERTPATH}/ssl/certs/consul-agent-ca.pem
     export CONSUL_CLIENT_CERT=/${ROOTCERTPATH}/consul.d/pki/tls/certs/consul-client.pem
     export CONSUL_CLIENT_KEY=/${ROOTCERTPATH}/consul.d/pki/tls/private/consul-client-key.pem
+    export CONSUL_HTTP_SSL=true
+    export CONSUL_GRPC_ADDR=https://127.0.0.1:8502
 
     # Configure CA Certificates for APP on host OS
     sudo mkdir -p /usr/local/share/ca-certificates
@@ -263,7 +259,7 @@ install_go_application () {
 
     # start connect application proxy
     sleep 5
-    start_app_proxy_service approle "App Role Vailt Secret ID Factory"
+    start_envoy_proxy_service approle "App Role Vault Secret ID Factory" approle 19002
     sleep 5
 
     curl http://127.0.0.1:8314/health 

--- a/scripts/install_SecretID_Factory.sh
+++ b/scripts/install_SecretID_Factory.sh
@@ -263,7 +263,7 @@ install_secret_id_application () {
     sleep 15
 
     # start envoy proxy
-    sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh  approle "App Role Vault Secret ID Factory "-sidecar-for approle" 19002 ${CONSUL_HTTP_TOKEN}
+    sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh  approle "App Role Vault Secret ID Factory" "-sidecar-for approle" 19002 ${CONSUL_HTTP_TOKEN}
     sleep 5
 
     curl http://127.0.0.1:8314/health 

--- a/scripts/install_consul.sh
+++ b/scripts/install_consul.sh
@@ -24,6 +24,7 @@ ports {
 connect {
     enabled = true
 }
+enable_central_service_config = true
 verify_incoming = true
 verify_outgoing = true
 key_file = "${2}"

--- a/scripts/install_envoy_proxy.sh
+++ b/scripts/install_envoy_proxy.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+setup_environment () {
+  set -x
+  sleep 5
+  source /usr/local/bootstrap/var.env
+  
+  IFACE=`route -n | awk '$1 == "192.168.9.0" {print $8;exit}'`
+  CIDR=`ip addr show ${IFACE} | awk '$2 ~ "192.168.9" {print $2}'`
+  IP=${CIDR%%/24}
+ 
+  if [ "${TRAVIS}" == "true" ]; then
+    ROOTCERTPATH=tmp
+    IP=${IP:-127.0.0.1}
+    LEADER_IP=${IP}
+  else
+    ROOTCERTPATH=etc
+  fi
+
+  export ROOTCERTPATH 
+}
+
+start_envoy_proxy_service () {
+  # start the new service mesh proxy for the application
+  # param 1 ${1}: app-proxy name
+  # param 2 ${2}: app-proxy service description
+  # param 3 ${3}: consul host service name
+  # param 4 ${4}: envoy proxy admin port needs to be different if running multiple instances on same host network
+
+  create_service "${1}" "${2}" "/usr/local/bin/consul connect envoy \
+                                                        -grpc-addr=https://127.0.0.1:8502 \
+                                                        -http-addr=https://127.0.0.1:8321 \
+                                                        -ca-file=/${ROOTCERTPATH}/ssl/certs/consul-agent-ca.pem \
+                                                        -client-cert=/${ROOTCERTPATH}/consul.d/pki/tls/certs/consul-client.pem \
+                                                        -client-key=/${ROOTCERTPATH}/consul.d/pki/tls/private/consul-client-key.pem \
+                                                        -token=${5} \
+                                                        -sidecar-for ${3} \
+                                                        -admin-bind localhost:${4}"
+
+  sudo systemctl start ${1}
+  #sudo systemctl status ${1}
+  echo "${1} Proxy App Service Build Complete"
+}
+
+create_service () {
+  # create a new systemd service
+  # param 1 ${1}: service/serviceuser name
+  # param 2 ${2}: service description
+  # param 3 ${3}: service start command
+  if [ ! -f /etc/systemd/system/${1}.service ]; then
+    
+    create_service_user ${1}
+    
+    sudo tee /etc/systemd/system/${1}.service <<EOF
+### BEGIN INIT INFO
+# Provides:          ${1}
+# Required-Start:    $local_fs $remote_fs
+# Required-Stop:     $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: ${1} service
+# Description:       ${2}
+### END INIT INFO
+
+[Unit]
+Description=${2}
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=${1}
+Group=${1}
+PIDFile=/var/run/${1}/${1}.pid
+PermissionsStartOnly=true
+ExecStartPre=-/bin/mkdir -p /var/run/${1}
+ExecStartPre=/bin/chown -R ${1}:${1} /var/run/${1}
+ExecStart=${3}
+ExecReload=/bin/kill -HUP ${MAINPID}
+KillMode=process
+KillSignal=SIGTERM
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  sudo systemctl daemon-reload
+
+  fi
+
+}
+
+create_service_user () {
+  
+  if ! grep ${1} /etc/passwd >/dev/null 2>&1; then
+    echo "Creating ${1} user to run the ${1} service"
+    sudo useradd --system --home /etc/${1}.d --shell /bin/false ${1}
+    sudo mkdir --parents /opt/${1} /usr/local/${1} /etc/${1}.d
+    sudo chown --recursive ${1}:${1} /opt/${1} /etc/${1}.d /usr/local/${1}
+  fi
+
+}
+
+
+setup_environment
+start_envoy_proxy_service "${1}" "${2}" "${3}" "${4}" "${5}"
+
+exit 0

--- a/scripts/install_envoy_proxy.sh
+++ b/scripts/install_envoy_proxy.sh
@@ -34,7 +34,7 @@ start_envoy_proxy_service () {
                                                         -client-cert=/${ROOTCERTPATH}/consul.d/pki/tls/certs/consul-client.pem \
                                                         -client-key=/${ROOTCERTPATH}/consul.d/pki/tls/private/consul-client-key.pem \
                                                         -token=${5} \
-                                                        -sidecar-for ${3} \
+                                                        ${3} \
                                                         -admin-bind localhost:${4}"
 
   sudo systemctl start ${1}

--- a/scripts/install_go_app.sh
+++ b/scripts/install_go_app.sh
@@ -173,13 +173,13 @@ register_secret_id_client_proxy_service_with_consul
 
 sleep 10
 # start envoy proxy for redis client
-sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh redisclientproxy "\"Redis Connect Client Proxy\"" "\"redis-client-tunnel\"" 19009 ${CONSUL_HTTP_TOKEN}
+sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh redisclientproxy "\"Redis Connect Client Proxy\"" "\"redis\"" 19009 ${CONSUL_HTTP_TOKEN}
 
 # create intention to connect from goapp to redis service
 create_intention_between_services "redis-client-tunnel" "redis"
 
 # start envoy proxy for secret id client
-sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh goclientproxy "\"SecretID Service Client Proxy Tunnel\"" "\"secret-id-tunnel\"" 19010 ${CONSUL_HTTP_TOKEN}
+sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh goclientproxy "\"SecretID Service Client Proxy Tunnel\"" "\"approle\"" 19010 ${CONSUL_HTTP_TOKEN}
 
 # create intention to connect from goapp to secret-id service
 create_intention_between_services "secret-id-tunnel" "approle"

--- a/scripts/install_go_app.sh
+++ b/scripts/install_go_app.sh
@@ -173,13 +173,13 @@ register_secret_id_client_proxy_service_with_consul
 
 sleep 10
 # start envoy proxy for redis client
-sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh redisclientproxy "\"Redis Connect Client Proxy\"" "\"redis\"" 19009 ${CONSUL_HTTP_TOKEN}
+sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh redisclientproxy "Redis Connect Client Proxy" "-proxy-id redis-client-tunnel" 19009 ${CONSUL_HTTP_TOKEN}
 
 # create intention to connect from goapp to redis service
 create_intention_between_services "redis-client-tunnel" "redis"
 
 # start envoy proxy for secret id client
-sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh goclientproxy "\"SecretID Service Client Proxy Tunnel\"" "\"approle\"" 19010 ${CONSUL_HTTP_TOKEN}
+sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh goclientproxy "SecretID Service Client Proxy Tunnel" "-proxy-id secret-id-tunnel" 19010 ${CONSUL_HTTP_TOKEN}
 
 # create intention to connect from goapp to secret-id service
 create_intention_between_services "secret-id-tunnel" "approle"

--- a/scripts/install_redis.sh
+++ b/scripts/install_redis.sh
@@ -84,7 +84,7 @@ register_redis_service_with_consul () {
         "connect": { "sidecar_service": {} }
     }
 EOF
-
+ 
   # Register the service in consul via the local Consul agent api
   sudo curl \
       --request PUT \
@@ -136,7 +136,7 @@ configure_redis () {
     sudo systemctl enable redis-server
     
     # start envoy proxy
-    sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh redis-proxy "\"Redis Proxy Service\"" redis 19001 ${CONSUL_HTTP_TOKEN}
+    sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh redis-proxy "Redis Proxy Service" "-sidecar-for redis" 19001 ${CONSUL_HTTP_TOKEN}
   else
     sudo redis-server /${ROOTCERTPATH}/redis/redis.conf &
 

--- a/scripts/install_redis.sh
+++ b/scripts/install_redis.sh
@@ -1,86 +1,5 @@
 #!/usr/bin/env bash
 
-create_service () {
-  # create a new systemd service
-  # param 1 ${1}: service/serviceuser name
-  # param 2 ${2}: service description
-  # param 3 ${3}: service start command
-  if [ ! -f /etc/systemd/system/${1}.service ]; then
-    
-    create_service_user ${1}
-    
-    sudo tee /etc/systemd/system/${1}.service <<EOF
-### BEGIN INIT INFO
-# Provides:          ${1}
-# Required-Start:    $local_fs $remote_fs
-# Required-Stop:     $local_fs $remote_fs
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Short-Description: ${1} service
-# Description:       ${2}
-### END INIT INFO
-
-[Unit]
-Description=${2}
-Requires=network-online.target
-After=network-online.target
-
-[Service]
-User=${1}
-Group=${1}
-PIDFile=/var/run/${1}/${1}.pid
-PermissionsStartOnly=true
-ExecStartPre=-/bin/mkdir -p /var/run/${1}
-ExecStartPre=/bin/chown -R ${1}:${1} /var/run/${1}
-ExecStart=${3}
-ExecReload=/bin/kill -HUP ${MAINPID}
-KillMode=process
-KillSignal=SIGTERM
-Restart=on-failure
-RestartSec=2s
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-  sudo systemctl daemon-reload
-
-  fi
-
-}
-
-create_service_user () {
-  
-  if ! grep ${1} /etc/passwd >/dev/null 2>&1; then
-    echo "Creating ${1} user to run the ${1} service"
-    sudo useradd --system --home /etc/${1}.d --shell /bin/false ${1}
-    sudo mkdir --parents /opt/${1} /usr/local/${1} /etc/${1}.d
-    sudo chown --recursive ${1}:${1} /opt/${1} /etc/${1}.d /usr/local/${1}
-  fi
-
-}
-
-start_envoy_proxy_service () {
-  # start the new service mesh proxy for the application
-  # param 1 ${1}: app-proxy name
-  # param 2 ${2}: app-proxy service description
-  # param 3 ${3}: consul host service name
-  # param 4 ${4}: envoy proxy admin port needs to be different if running multiple instances on same host network
-
-  create_service "${1}" "${2}" "/usr/local/bin/consul connect envoy \
-                                                        -http-addr=https://127.0.0.1:8321 \
-                                                        -ca-file=/${ROOTCERTPATH}/ssl/certs/consul-agent-ca.pem \
-                                                        -client-cert=/${ROOTCERTPATH}/consul.d/pki/tls/certs/consul-client.pem \
-                                                        -client-key=/${ROOTCERTPATH}/consul.d/pki/tls/private/consul-client-key.pem \
-                                                        -token=${CONSUL_HTTP_TOKEN} \
-                                                        -sidecar-for ${3} \
-                                                        -admin-bind localhost:${4}"
-  sudo usermod -a -G webpagecountercerts ${1}
-  sudo systemctl start ${1}
-  #sudo systemctl status ${1}
-  echo "${1} Proxy App Service Build Complete"
-}
-
 setup_environment () {
   set -x
   source /usr/local/bootstrap/var.env
@@ -216,8 +135,8 @@ configure_redis () {
     sudo systemctl start redis-server
     sudo systemctl enable redis-server
     
-    # start connect application proxy
-    start_envoy_proxy_service redis-proxy "Redis Proxy Service" redis 19001
+    # start envoy proxy
+    sudo /usr/local/bootstrap/scripts/install_envoy_proxy.sh redis-proxy "\"Redis Proxy Service\"" redis 19001 ${CONSUL_HTTP_TOKEN}
   else
     sudo redis-server /${ROOTCERTPATH}/redis/redis.conf &
 

--- a/scripts/install_redis.sh
+++ b/scripts/install_redis.sh
@@ -149,7 +149,7 @@ configure_redis () {
 
 setup_environment
 configure_redis
-sudo systemctl status redis-server
+#sudo systemctl status redis-server
 
 exit 0
 

--- a/scripts/nomad_job.hcl
+++ b/scripts/nomad_job.hcl
@@ -8,7 +8,7 @@ job "webpagecounter" {
         driver = "raw_exec"
         config {
             command = "/usr/local/bin/webcounter"
-            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=eb2875ff-786c-08ef-b4d6-8051745bd901", "-consulIP=192.168.9.11:8321"]
+            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=eb04c3dd-b1d3-f6f4-8f43-4ca50e329960", "-consulIP=192.168.9.11:8321"]
         }
         resources {
           cpu    = 20

--- a/scripts/nomad_job.hcl
+++ b/scripts/nomad_job.hcl
@@ -8,7 +8,7 @@ job "webpagecounter" {
         driver = "raw_exec"
         config {
             command = "/usr/local/bin/webcounter"
-            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=79b78440-287e-7eb7-0aa1-d7dea101a29e", "-consulIP=192.168.9.11:8321"]
+            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=4dab4da5-3f94-d330-9575-8a5ed544bd3d", "-consulIP=192.168.9.11:8321"]
         }
         resources {
           cpu    = 20

--- a/scripts/nomad_job.hcl
+++ b/scripts/nomad_job.hcl
@@ -8,7 +8,7 @@ job "webpagecounter" {
         driver = "raw_exec"
         config {
             command = "/usr/local/bin/webcounter"
-            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=9142caff-edf7-90fe-c306-264e2b064f96", "-consulIP=192.168.9.11:8321"]
+            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=ddf3c629-823a-15c6-b677-4e02b59c1b43", "-consulIP=192.168.9.11:8321"]
         }
         resources {
           cpu    = 20

--- a/scripts/nomad_job.hcl
+++ b/scripts/nomad_job.hcl
@@ -8,7 +8,7 @@ job "webpagecounter" {
         driver = "raw_exec"
         config {
             command = "/usr/local/bin/webcounter"
-            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=4dab4da5-3f94-d330-9575-8a5ed544bd3d", "-consulIP=192.168.9.11:8321"]
+            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=5ce6df8e-746a-61be-a0f1-0f484d7db7e6", "-consulIP=192.168.9.11:8321"]
         }
         resources {
           cpu    = 20

--- a/scripts/nomad_job.hcl
+++ b/scripts/nomad_job.hcl
@@ -8,7 +8,7 @@ job "webpagecounter" {
         driver = "raw_exec"
         config {
             command = "/usr/local/bin/webcounter"
-            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=eb04c3dd-b1d3-f6f4-8f43-4ca50e329960", "-consulIP=192.168.9.11:8321"]
+            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=79b78440-287e-7eb7-0aa1-d7dea101a29e", "-consulIP=192.168.9.11:8321"]
         }
         resources {
           cpu    = 20

--- a/scripts/nomad_job.hcl
+++ b/scripts/nomad_job.hcl
@@ -8,7 +8,7 @@ job "webpagecounter" {
         driver = "raw_exec"
         config {
             command = "/usr/local/bin/webcounter"
-            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=50aa34cd-36ad-4ac0-ee29-5abae9b502c6", "-consulIP=192.168.9.11:8321"]
+            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=9142caff-edf7-90fe-c306-264e2b064f96", "-consulIP=192.168.9.11:8321"]
         }
         resources {
           cpu    = 20

--- a/scripts/nomad_job.hcl
+++ b/scripts/nomad_job.hcl
@@ -8,7 +8,7 @@ job "webpagecounter" {
         driver = "raw_exec"
         config {
             command = "/usr/local/bin/webcounter"
-            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=ddf3c629-823a-15c6-b677-4e02b59c1b43", "-consulIP=192.168.9.11:8321"]
+            args = ["-port=${NOMAD_PORT_http}", "-ip=0.0.0.0", "-consulACL=eb2875ff-786c-08ef-b4d6-8051745bd901", "-consulIP=192.168.9.11:8321"]
         }
         resources {
           cpu    = 20


### PR DESCRIPTION
# Why is the PR required?


### Refactor:

Adopt envoy proxy for Consul Service Mesh

## What does this PR do?

Implement Consul Service Mesh using Envoy Proxy

## How was this PR implemented?

Installed Envoy on base image and then redefined service definitions and proxy startup procedures, enabled grpc etc for envoy usage...

## How long did it take?

2 weeks of phaffing - docs are a confusing mix of json and hcl examples mixed with both envoy and built-in configurations...

## NOTE: This does not leverage the native Consul Connect -> Nomad integrations yet. Each host vm receives an Envoy proxy to channel all instances of the applications requests - one proxy for approle and another for redis.

I need to port to CNI to start leveraging the Consul/Nomad integrations.
